### PR TITLE
Add ability to pre process contents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,11 @@ function createDocumentIndex(opts, file, path){
   }
   for (field in opts.fields){
     if(field == 'contents'){
-      index.contents = file.contents.toString();
+      if(typeof opts.preprocess === 'function'){
+        index.contents = opts.preprocess.call(file, file.contents.toString());
+      }else{
+        index.contents = file.contents.toString();
+      }
     }else{
       index[field] = file[field];
     }


### PR DESCRIPTION
There might be a time when you want to massage the contents being index prior to indexing. For example striping HTML tags. Add a `preprocess` call back option to handle this. The callback will be passed the contents of the file as a string as the forst argument nd the actual file object as the `this` context.
